### PR TITLE
Add unit tests for contract document Netlify functions

### DIFF
--- a/netlify/functions/__tests__/contract-data.test.js
+++ b/netlify/functions/__tests__/contract-data.test.js
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const handlerPath = require.resolve('../contract-data.js');
+const pgPath = require.resolve('pg');
+const originalPg = require.cache[pgPath];
+
+function restore() {
+  delete require.cache[handlerPath];
+  if (originalPg) require.cache[pgPath] = originalPg;
+  else delete require.cache[pgPath];
+}
+
+function loadHandlerWithMock(ClientImpl) {
+  require.cache[pgPath] = { exports: { Client: ClientImpl } };
+  delete require.cache[handlerPath];
+  return require('../contract-data.js').handler;
+}
+
+test('returns 400 when cer_id is missing', async (t) => {
+  t.after(() => {
+    restore();
+  });
+  delete process.env.NEON_DATABASE_URL;
+  delete process.env.DATABASE_URL;
+  delete process.env.NETLIFY_DATABASE_URL;
+  delete process.env.NETLIFY_DATABASE_URL_UNPOOLED;
+
+  const handler = loadHandlerWithMock(class {
+    async connect() {}
+    async query() { throw new Error('should not query without cer_id'); }
+    async end() {}
+  });
+
+  const res = await handler({ queryStringParameters: null });
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body), { error: 'cer_id mancante' });
+});
+
+test('returns 500 when database url is missing', async (t) => {
+  t.after(() => {
+    restore();
+  });
+  delete process.env.NEON_DATABASE_URL;
+  delete process.env.DATABASE_URL;
+  delete process.env.NETLIFY_DATABASE_URL;
+  delete process.env.NETLIFY_DATABASE_URL_UNPOOLED;
+
+  const handler = loadHandlerWithMock(class {
+    async connect() { throw new Error('should not connect without db url'); }
+    async query() {}
+    async end() {}
+  });
+
+  const res = await handler({ queryStringParameters: { cer_id: 'abc' } });
+  assert.equal(res.statusCode, 500);
+  assert.deepEqual(JSON.parse(res.body), { error: 'DB non configurato' });
+});
+
+test('returns cer data with members and riparti', async (t) => {
+  t.after(() => {
+    restore();
+    delete process.env.NEON_DATABASE_URL;
+  });
+
+  process.env.NEON_DATABASE_URL = 'postgres://example';
+  const queries = [];
+  class MockClient {
+    constructor() {
+      this.connected = false;
+      this.closed = false;
+    }
+    async connect() {
+      this.connected = true;
+    }
+    async query(sql, params) {
+      queries.push({ sql, params });
+      if (sql.startsWith('SELECT id,nome,cabina')) {
+        return { rows: [{ id: 'cer-1', nome: 'CER Uno', cabina: 'CAB-1', quota_condivisa: 50, riparti: { foo: 'bar' } }] };
+      }
+      if (sql.startsWith('SELECT pod,cabina')) {
+        return { rows: [{ pod: 'IT123', cabina: 'CAB-1' }, { pod: 'IT456', cabina: 'CAB-2' }] };
+      }
+      if (sql.includes('CREATE TABLE IF NOT EXISTS cer_members')) {
+        return { rows: [] };
+      }
+      if (sql.startsWith('SELECT id,role,display_name')) {
+        return { rows: [{ id: 'mem-1', role: 'PRESIDENTE', display_name: 'Mario Rossi', cf_piva: 'RSSMRA', pec: 'mario@pec', email: 'mario@example.com' }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    }
+    async end() {
+      this.closed = true;
+    }
+  }
+
+  const handler = loadHandlerWithMock(MockClient);
+
+  const res = await handler({ queryStringParameters: { cer_id: 'cer-1' } });
+  assert.equal(res.statusCode, 200);
+  const payload = JSON.parse(res.body);
+  assert.deepEqual(payload.cer, { id: 'cer-1', nome: 'CER Uno', cabina: 'CAB-1', quota_condivisa: 50, riparti: { foo: 'bar' } });
+  assert.equal(payload.pod_univoco, 'IT123');
+  assert.deepEqual(payload.membri, [{ id: 'mem-1', role: 'PRESIDENTE', display_name: 'Mario Rossi', cf_piva: 'RSSMRA', pec: 'mario@pec', email: 'mario@example.com' }]);
+  assert.deepEqual(payload.riparti, { foo: 'bar' });
+  assert.equal(typeof payload.generated_at, 'number');
+
+  assert.ok(queries.some(q => q.sql.includes('CREATE TABLE IF NOT EXISTS cer_members')));
+});

--- a/netlify/functions/__tests__/save-doc.test.js
+++ b/netlify/functions/__tests__/save-doc.test.js
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const handlerPath = require.resolve('../save-doc.js');
+const pgPath = require.resolve('pg');
+const originalPg = require.cache[pgPath];
+
+function restore() {
+  delete require.cache[handlerPath];
+  if (originalPg) require.cache[pgPath] = originalPg;
+  else delete require.cache[pgPath];
+}
+
+function loadHandlerWithMock(ClientImpl) {
+  require.cache[pgPath] = { exports: { Client: ClientImpl } };
+  delete require.cache[handlerPath];
+  return require('../save-doc.js').handler;
+}
+
+test('rejects non POST methods', async (t) => {
+  t.after(restore);
+  const handler = loadHandlerWithMock(class {
+    async connect() { throw new Error('should not connect'); }
+    async query() {}
+    async end() {}
+  });
+
+  const res = await handler({ httpMethod: 'GET' });
+  assert.equal(res.statusCode, 405);
+  assert.deepEqual(JSON.parse(res.body), { error: 'Metodo non consentito' });
+});
+
+test('rejects invalid JSON', async (t) => {
+  t.after(restore);
+  const handler = loadHandlerWithMock(class {
+    async connect() { throw new Error('should not connect'); }
+    async query() {}
+    async end() {}
+  });
+
+  const res = await handler({ httpMethod: 'POST', body: 'non-json' });
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body), { error: 'JSON non valido' });
+});
+
+test('requires mandatory fields', async (t) => {
+  t.after(restore);
+  const handler = loadHandlerWithMock(class {
+    async connect() { throw new Error('should not connect'); }
+    async query() {}
+    async end() {}
+  });
+
+  const res = await handler({ httpMethod: 'POST', body: JSON.stringify({}) });
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body), { error: 'campi obbligatori: cer_id, doc_type, filename, content_base64' });
+});
+
+test('saves document content to the database', async (t) => {
+  t.after(() => {
+    restore();
+    delete process.env.NEON_DATABASE_URL;
+  });
+
+  process.env.NEON_DATABASE_URL = 'postgres://example';
+  const executed = [];
+
+  class MockClient {
+    async connect() {
+      executed.push({ step: 'connect' });
+    }
+    async query(sql, params) {
+      if (sql.includes('CREATE TABLE IF NOT EXISTS cer_docs')) {
+        executed.push({ step: 'create-table' });
+        return { rows: [] };
+      }
+      if (sql.startsWith('INSERT INTO cer_docs')) {
+        executed.push({ step: 'insert', params });
+        return { rows: [] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    }
+    async end() {
+      executed.push({ step: 'end' });
+    }
+  }
+
+  const handler = loadHandlerWithMock(MockClient);
+  const body = {
+    cer_id: 'cer-1',
+    doc_type: 'test',
+    filename: 'documento.txt',
+    content_base64: Buffer.from('ciao mondo', 'utf8').toString('base64')
+  };
+
+  const res = await handler({ httpMethod: 'POST', body: JSON.stringify(body) });
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), { ok: true });
+
+  const insertCall = executed.find(e => e.step === 'insert');
+  assert.ok(insertCall, 'expected an insert query');
+  const params = insertCall.params;
+  assert.equal(params[1], 'cer-1');
+  assert.equal(params[2], 'test');
+  assert.equal(params[3], 'documento.txt');
+  assert.equal(params[4], 'text/plain');
+  assert.ok(Buffer.isBuffer(params[5]));
+  assert.equal(params[5].toString('utf8'), 'ciao mondo');
+});

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "1.0.0",
   "license": "UNLICENSED",
+  "scripts": {
+    "test": "node --test netlify/functions/__tests__/*.test.js"
+  },
   "dependencies": {
     "firebase-admin": "^12.6.0",
     "pg": "^8.12.0"


### PR DESCRIPTION
## Summary
- add node:test suites that mock the pg client and cover the contract-data and save-doc handlers
- ensure the project exposes an npm test script to execute the new suites

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ea11d0802483219c4286d7cce7a985